### PR TITLE
Minor improvements

### DIFF
--- a/StIstSimMaker/StIstFastSimMaker.cxx
+++ b/StIstSimMaker/StIstFastSimMaker.cxx
@@ -20,7 +20,7 @@
 
 ClassImp(StIstFastSimMaker)
 
-StIstFastSimMaker::StIstFastSimMaker( const Char_t *name, bool useRandomSeed) : StMaker(name), mIstRot(NULL), mIstDb(NULL), mBuildIdealGeom(kTRUE),
+StIstFastSimMaker::StIstFastSimMaker( const Char_t *name, bool useRandomSeed) : StMaker(name), mIstRot(NULL), mIstDb(NULL), mBuildIdealGeom(kFALSE),
    mRandom(useRandomSeed ? time(0) : 65539), mSmear(kTRUE)
 {
 }

--- a/StIstSimMaker/StIstFastSimMaker.cxx
+++ b/StIstSimMaker/StIstFastSimMaker.cxx
@@ -73,6 +73,15 @@ Int_t StIstFastSimMaker::InitRun(int runNo)
       return kStFatal;
    }
 
+   if(mBuildIdealGeom)
+   {
+     LOG_DEBUG << " Using ideal geometry" << endm;
+   }
+   else
+   {
+     LOG_DEBUG << " Using geometry tables from the DB." << endm;
+   }
+
    return kStOk;
 }
 
@@ -144,6 +153,8 @@ Int_t StIstFastSimMaker::Make()
          Double_t globalIstHitPos[3] = {mcI->position().x(), mcI->position().y(), mcI->position().z()};
          Double_t localIstHitPos[3] = {mcI->position().x(), mcI->position().y(), mcI->position().z()};
 
+         LOG_DEBUG << "ladder/wafer = " << mcI->ladder() << " / " << mcI->wafer() << endm;
+         LOG_DEBUG << "x/y/z before smearing" << localIstHitPos[0] << "/" << localIstHitPos[1] << "/" << localIstHitPos[2] << endm;
          if (mSmear) { // smearing on
             localIstHitPos[0] = distortHit(localIstHitPos[0], mResXIst1, kIstSensorActiveSizeRPhi / 2.0);
             localIstHitPos[2] = distortHit(localIstHitPos[2], mResZIst1, kIstSensorActiveSizeZ / 2.0);
@@ -159,6 +170,7 @@ Int_t StIstFastSimMaker::Make()
             localIstHitPos[0] = kIstSensorActiveSizeRPhi / 2.0 - rPhiPos;
             localIstHitPos[2] = zPos - kIstSensorActiveSizeZ / 2.0;
          }
+         LOG_DEBUG << "x/y/z after smearing" << localIstHitPos[0] << "/" << localIstHitPos[1] << "/" << localIstHitPos[2] << endm;
 
          //YPWANG: do local-->global transform with geometry table
          combI->LocalToMaster(localIstHitPos, globalIstHitPos);


### PR DESCRIPTION
I suggest that the default geometry tables used in StIstFastSimMaker to be from whatever is loaded in StIstDb. 

This way we can always choose the geometry by chain (e.g. y2014a or ry2014a) and it will automatically work for simulation or embedding. 